### PR TITLE
Use hr element instead of div for separator

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -41,8 +41,7 @@ class ObsifetchModal extends Modal {
           cls: 'vault-header'
       });
   
-      infoSection.createEl('div', {
-          text: '-'.repeat(36),
+      infoSection.createEl('hr', {
           cls: 'vault-separator'
       });
   

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,7 @@
 
 .vault-separator {
     color: var(--text-muted);
+    border-color: var(--text-muted);
     margin-bottom: 0.5em;
 }
 


### PR DESCRIPTION
Using a `hr` rather than a div would show better on smaller displays.